### PR TITLE
포인트 충전, 사용에 대한 정책과 단위테스트 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+.gradle

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .gradle
+build

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,3 +50,7 @@ tasks.test {
     ignoreFailures = true
     useJUnitPlatform()
 }
+
+tasks.withType<JavaCompile> {
+    options.compilerArgs.add("-parameters")
+}

--- a/src/main/java/io/hhplus/tdd/common/PointConstants.java
+++ b/src/main/java/io/hhplus/tdd/common/PointConstants.java
@@ -1,4 +1,15 @@
 package io.hhplus.tdd.common;
 
 public class PointConstants {
+
+    public static final long NEW_MEMBER_INITIAL_POINT = 0L;
+    public static final long MINIMUM_CHARGE_AMOUNT = 1L;
+    public static final long MAXIMUM_CHARGE_AMOUNT = 100000L;
+    public static final long MINIMUM_USE_AMOUNT = 1L;
+    public static final long MAXIMUM_USE_AMOUNT = 10000L;
+    public static final long MAXIMUM_BALANCE = 100000L;
+
+    //인스턴스화 방지
+    private PointConstants() {
+    }
 }

--- a/src/main/java/io/hhplus/tdd/common/PointConstants.java
+++ b/src/main/java/io/hhplus/tdd/common/PointConstants.java
@@ -1,0 +1,4 @@
+package io.hhplus.tdd.common;
+
+public class PointConstants {
+}

--- a/src/main/java/io/hhplus/tdd/point/PointController.java
+++ b/src/main/java/io/hhplus/tdd/point/PointController.java
@@ -11,6 +11,11 @@ import java.util.List;
 public class PointController {
 
     private static final Logger log = LoggerFactory.getLogger(PointController.class);
+    private final PointService pointService;
+
+    public PointController(PointService pointService) {
+        this.pointService = pointService;
+    }
 
     /**
      * TODO - 특정 유저의 포인트를 조회하는 기능을 작성해주세요.
@@ -19,7 +24,8 @@ public class PointController {
     public UserPoint point(
             @PathVariable long id
     ) {
-        return new UserPoint(0, 0, 0);
+        log.info("포인트 조회 요청: userId={}", id);
+        return pointService.getPointOf(id);
     }
 
     /**
@@ -29,7 +35,8 @@ public class PointController {
     public List<PointHistory> history(
             @PathVariable long id
     ) {
-        return List.of();
+        log.info("포인트 충전/이용 내역 조회 요청: userId={}", id);
+        return pointService.getPointHistoriesOf(id);
     }
 
     /**
@@ -40,7 +47,8 @@ public class PointController {
             @PathVariable long id,
             @RequestBody long amount
     ) {
-        return new UserPoint(0, 0, 0);
+        log.info("포인트 충전 요청: userId={}", id);
+        return pointService.chargePointOf(id, amount);
     }
 
     /**
@@ -51,6 +59,7 @@ public class PointController {
             @PathVariable long id,
             @RequestBody long amount
     ) {
-        return new UserPoint(0, 0, 0);
+        log.info("포인트 사용 요청: userId={}", id);
+        return pointService.usePointOf(id, amount);
     }
 }

--- a/src/main/java/io/hhplus/tdd/point/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/PointService.java
@@ -1,0 +1,60 @@
+package io.hhplus.tdd.point;
+
+import io.hhplus.tdd.database.PointHistoryTable;
+import io.hhplus.tdd.database.UserPointTable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class PointService {
+
+    private final UserPointTable userPointTable;
+    private final PointHistoryTable pointHistoryTable;
+
+    // 포인트 조회
+    public UserPoint getPointOf(long userId) {
+        return userPointTable.selectById(userId);
+    }
+
+    // 히스토리 조회
+    public List<PointHistory> getPointHistoriesOf(long userId) {
+        return pointHistoryTable.selectAllByUserId(userId);
+    }
+
+    // 포인트 충전
+    public UserPoint chargePointOf(long userId, long amount) {
+        long balance = currentPointOf(userId) + amount;
+        return updatePointBalance(userId, balance, TransactionType.CHARGE);
+    }
+
+    // 포인트 사용
+    public UserPoint usePointOf(long userId, long amount) {
+        long currentPoint = currentPointOf(userId);
+        if (currentPoint < amount) {
+            throw new IllegalArgumentException("잔고 부족 (현재잔고: " + currentPoint + "원)");
+        }
+
+        long balance = currentPoint - amount;
+        return updatePointBalance(userId, balance, TransactionType.USE);
+    }
+
+    // 포인트 사용 or 충전 시 잔액 갱신
+    public UserPoint updatePointBalance(long userId, long newAmount, TransactionType type) {
+        UserPoint updatedPoint = userPointTable.insertOrUpdate(userId, newAmount);
+        pointHistoryTable.insert(userId, newAmount, type, currentTime());
+        return updatedPoint;
+    }
+
+
+    private long currentPointOf(long userId) {
+        return getPointOf(userId).point();
+    }
+
+    private long currentTime() {
+        return System.currentTimeMillis();
+    }
+
+}

--- a/src/main/java/io/hhplus/tdd/point/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/PointService.java
@@ -28,34 +28,38 @@ public class PointService {
     public UserPoint chargePointOf(long userId, long amount) {
         // 충전 금액 검증
         PointValidator.validateChargeAmount(amount);
-        long currentPoint = currentPointOf(userId);
-        // 잔액 검증
-        PointValidator.validateChargeBalance(currentPoint, amount);
-        long balance = currentPoint + amount;
 
-        return updatePointBalance(userId, balance, TransactionType.CHARGE, amount);
+        // 잔액 검증
+        UserPoint current = getUserOf(userId);
+        PointValidator.validateChargeBalance(current.point(), amount);
+        UserPoint charged = current.charge(amount);
+
+        return updatePointBalance(charged, TransactionType.CHARGE, amount);
     }
 
     // 포인트 사용
     public UserPoint usePointOf(long userId, long amount) {
         // 사용 금액 검증
         PointValidator.validateUseAmount(amount);
-        long currentPoint = currentPointOf(userId);
+
         // 잔액 검증
-        PointValidator.validateSufficientBalance(currentPoint, amount);
-        long balance = currentPoint - amount;
-        return updatePointBalance(userId, balance, TransactionType.USE, amount);
+        UserPoint current = getUserOf(userId);
+        PointValidator.validateSufficientBalance(current.point(), amount);
+        UserPoint used = current.use(amount);
+
+        return updatePointBalance(used, TransactionType.USE, amount);
+    }
+
+    public UserPoint getUserOf(long userId) {
+        UserPoint current = userPointTable.selectById(userId);
+        return current;
     }
 
     // 포인트 사용 or 충전 시 잔액 갱신
-    public UserPoint updatePointBalance(long userId, long newBalance, TransactionType type, long transactionAmount) {
-        UserPoint updatedPoint = userPointTable.insertOrUpdate(userId, newBalance);
-        pointHistoryTable.insert(userId, transactionAmount, type, updatedPoint.updateMillis());
+    public UserPoint updatePointBalance(UserPoint userPoint, TransactionType type, long transactionAmount) {
+        UserPoint updatedPoint = userPointTable.insertOrUpdate(userPoint.id(), userPoint.point());
+        pointHistoryTable.insert(userPoint.id(), transactionAmount, type, updatedPoint.updateMillis());
         return updatedPoint;
-    }
-
-    public long currentPointOf(long userId) {
-        return getPointOf(userId).point();
     }
 
 }

--- a/src/main/java/io/hhplus/tdd/point/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/PointService.java
@@ -33,7 +33,7 @@ public class PointService {
         PointValidator.validateChargeBalance(currentPoint, amount);
         long balance = currentPoint + amount;
 
-        return updatePointBalance(userId, balance, TransactionType.CHARGE);
+        return updatePointBalance(userId, balance, TransactionType.CHARGE, amount);
     }
 
     // 포인트 사용
@@ -44,23 +44,18 @@ public class PointService {
         // 잔액 검증
         PointValidator.validateSufficientBalance(currentPoint, amount);
         long balance = currentPoint - amount;
-        return updatePointBalance(userId, balance, TransactionType.USE);
+        return updatePointBalance(userId, balance, TransactionType.USE, amount);
     }
 
     // 포인트 사용 or 충전 시 잔액 갱신
-    public UserPoint updatePointBalance(long userId, long newAmount, TransactionType type) {
-        UserPoint updatedPoint = userPointTable.insertOrUpdate(userId, newAmount);
-        pointHistoryTable.insert(userId, newAmount, type, currentTime());
+    public UserPoint updatePointBalance(long userId, long newBalance, TransactionType type, long transactionAmount) {
+        UserPoint updatedPoint = userPointTable.insertOrUpdate(userId, newBalance);
+        pointHistoryTable.insert(userId, transactionAmount, type, updatedPoint.updateMillis());
         return updatedPoint;
     }
 
-
-    private long currentPointOf(long userId) {
+    public long currentPointOf(long userId) {
         return getPointOf(userId).point();
-    }
-
-    private long currentTime() {
-        return System.currentTimeMillis();
     }
 
 }

--- a/src/main/java/io/hhplus/tdd/point/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/PointService.java
@@ -26,17 +26,23 @@ public class PointService {
 
     // 포인트 충전
     public UserPoint chargePointOf(long userId, long amount) {
-        long balance = currentPointOf(userId) + amount;
+        // 충전 금액 검증
+        PointValidator.validateChargeAmount(amount);
+        long currentPoint = currentPointOf(userId);
+        // 잔액 검증
+        PointValidator.validateChargeBalance(currentPoint, amount);
+        long balance = currentPoint + amount;
+
         return updatePointBalance(userId, balance, TransactionType.CHARGE);
     }
 
     // 포인트 사용
     public UserPoint usePointOf(long userId, long amount) {
+        // 사용 금액 검증
+        PointValidator.validateUseAmount(amount);
         long currentPoint = currentPointOf(userId);
-        if (currentPoint < amount) {
-            throw new IllegalArgumentException("잔고 부족 (현재잔고: " + currentPoint + "원)");
-        }
-
+        // 잔액 검증
+        PointValidator.validateSufficientBalance(currentPoint, amount);
         long balance = currentPoint - amount;
         return updatePointBalance(userId, balance, TransactionType.USE);
     }

--- a/src/main/java/io/hhplus/tdd/point/PointValidator.java
+++ b/src/main/java/io/hhplus/tdd/point/PointValidator.java
@@ -1,0 +1,51 @@
+package io.hhplus.tdd.point;
+
+import static io.hhplus.tdd.common.PointConstants.*;
+
+public class PointValidator {
+
+    public static void validateChargeAmount(long amount) {
+        validateMinimumAmount(amount, MINIMUM_CHARGE_AMOUNT, "충전");
+        validateMaximumAmount(amount, MAXIMUM_CHARGE_AMOUNT, "충전");
+    }
+
+    public static void validateChargeBalance(long currentPoint, long amount) {
+        if (currentPoint + amount > MAXIMUM_BALANCE) {
+            throw new IllegalArgumentException(String.format("보유 가능한 최대 포인트를 초과했습니다. (최대 보유 가능 포인트: %d)", MAXIMUM_BALANCE));
+        }
+    }
+
+    public static void validateUseAmount(long amount) {
+        validateMinimumAmount(amount, MINIMUM_USE_AMOUNT, "사용");
+        validateMaximumAmount(amount, MAXIMUM_USE_AMOUNT, "사용");
+    }
+
+    public static void validateSufficientBalance(long currentPoint, long amount) {
+        if (currentPoint < amount) {
+            throw new IllegalArgumentException(String.format("사용할 포인트가 부족합니다. (현재 보유 포인트: %d)", currentPoint));
+        }
+    }
+
+    private static void validateMinimumAmount(long amount, long minimumAmount, String transactionType) {
+        if (amount < minimumAmount) {
+            throw new IllegalArgumentException(String.format(
+                    "%d 포인트 이상 %s해주세요",
+                    minimumAmount,
+                    transactionType
+            ));
+        }
+    }
+
+    private static void validateMaximumAmount(long amount, long maximumAmount, String transactionType) {
+        if (amount > maximumAmount) {
+            throw new IllegalArgumentException(String.format(
+                    "1회 최대 %s금액은  %d입니다.",
+                    transactionType,
+                    maximumAmount
+            ));
+        }
+    }
+
+    private PointValidator() {
+    }
+}

--- a/src/main/java/io/hhplus/tdd/point/PointValidator.java
+++ b/src/main/java/io/hhplus/tdd/point/PointValidator.java
@@ -29,7 +29,7 @@ public class PointValidator {
     private static void validateMinimumAmount(long amount, long minimumAmount, String transactionType) {
         if (amount < minimumAmount) {
             throw new IllegalArgumentException(String.format(
-                    "%d 포인트 이상 %s해주세요",
+                    "%d 포인트 이상 %s해주세요.",
                     minimumAmount,
                     transactionType
             ));
@@ -39,7 +39,7 @@ public class PointValidator {
     private static void validateMaximumAmount(long amount, long maximumAmount, String transactionType) {
         if (amount > maximumAmount) {
             throw new IllegalArgumentException(String.format(
-                    "1회 최대 %s금액은  %d입니다.",
+                    "1회 최대 %s금액은 %d입니다.",
                     transactionType,
                     maximumAmount
             ));

--- a/src/main/java/io/hhplus/tdd/point/PointValidator.java
+++ b/src/main/java/io/hhplus/tdd/point/PointValidator.java
@@ -26,7 +26,7 @@ public class PointValidator {
         }
     }
 
-    private static void validateMinimumAmount(long amount, long minimumAmount, String transactionType) {
+    public static void validateMinimumAmount(long amount, long minimumAmount, String transactionType) {
         if (amount < minimumAmount) {
             throw new IllegalArgumentException(String.format(
                     "%d 포인트 이상 %s해주세요.",
@@ -36,7 +36,7 @@ public class PointValidator {
         }
     }
 
-    private static void validateMaximumAmount(long amount, long maximumAmount, String transactionType) {
+    public static void validateMaximumAmount(long amount, long maximumAmount, String transactionType) {
         if (amount > maximumAmount) {
             throw new IllegalArgumentException(String.format(
                     "1회 최대 %s금액은 %d입니다.",

--- a/src/main/java/io/hhplus/tdd/point/UserPoint.java
+++ b/src/main/java/io/hhplus/tdd/point/UserPoint.java
@@ -9,4 +9,12 @@ public record UserPoint(
     public static UserPoint empty(long id) {
         return new UserPoint(id, 0, System.currentTimeMillis());
     }
+
+    public UserPoint charge(long amount) {
+        return new UserPoint(id, point + amount, System.currentTimeMillis());
+    }
+
+    public UserPoint use(long amount) {
+        return new UserPoint(id, point - amount, System.currentTimeMillis());
+    }
 }

--- a/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
@@ -1,0 +1,4 @@
+package io.hhplus.tdd.point;
+
+public class PointServiceTest {
+}

--- a/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
@@ -134,7 +134,7 @@ public class PointServiceTest {
         @Test
         void 최대_잔고_초과_예외_처리 () {
             //given
-            long chargeAmount = MAXIMUM_CHARGE_AMOUNT - CURRENT_POINT + 1L;
+            long chargeAmount = MAXIMUM_BALANCE - CURRENT_POINT + 1L;
             given(userPointTable.selectById(USER_ID))
                     .willReturn(new UserPoint(USER_ID, CURRENT_POINT, UPDATE_MILLIS));
 

--- a/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
@@ -1,4 +1,265 @@
 package io.hhplus.tdd.point;
 
-public class PointServiceTest {
+import io.hhplus.tdd.database.PointHistoryTable;
+import io.hhplus.tdd.database.UserPointTable;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class PointServiceUnitTest {
+
+    // 기본 값
+    private final Long USER_ID = 1L;
+    private final Long UPDATE_MILLIS = 10000L;
+    private final Long CURRENT_POINT = 1000L;
+
+    // 비즈니스 요구사항
+    private final Long NEW_MEMBER_INITIAL_POINT = 0L;
+    private final Long MINIMUM_CHARGE_AMOUNT = 1L;
+    private final Long MAXIMUM_CHARGE_AMOUNT = 10000L;
+    private final Long MINIMUM_USE_AMOUNT = 1L;
+    private final Long MAXIMUM_USE_AMOUNT = 10000L;
+    private final Long MAXIMUM_BALANCE = 100000L;
+
+    @Mock
+    private UserPointTable userPointTable;
+    @Mock
+    private PointHistoryTable pointHistoryTable;
+    @InjectMocks
+    private PointService pointService;
+
+    @Nested
+    class 조회 {
+
+        @Test
+        void 유저_포인트_정상_조회() {
+            //given
+            given(userPointTable.selectById(USER_ID))
+                    .willReturn(new UserPoint(USER_ID, CURRENT_POINT, UPDATE_MILLIS));
+            //when, then
+            assertThat(pointService.getPointOf(USER_ID))
+                    .extracting("id", "point", "updateMillis")
+                    .containsExactly(USER_ID, CURRENT_POINT, UPDATE_MILLIS);
+            verify(userPointTable).selectById(USER_ID);
+        }
+
+        @Test
+        void 미등록_유저일_경우_초기_포인트() {
+            //given
+            given(userPointTable.selectById(USER_ID))
+                    .willReturn(new UserPoint(USER_ID, NEW_MEMBER_INITIAL_POINT, UPDATE_MILLIS));
+            //when, then
+            assertThat(pointService.getPointOf(USER_ID))
+                    .extracting("id", "point", "updateMillis")
+                    .containsExactly(USER_ID, NEW_MEMBER_INITIAL_POINT, UPDATE_MILLIS);
+            verify(userPointTable).selectById(USER_ID);
+        }
+
+        @Test
+        void 유저_포인트_히스토리_정상조회() {
+            //given
+            List<PointHistory> history = List.of(
+                    new PointHistory(1L, USER_ID, 100L, TransactionType.CHARGE, 10000L),
+                    new PointHistory(2L, USER_ID, 50L, TransactionType.USE, 10005L),
+                    new PointHistory(3L, USER_ID, 70L, TransactionType.CHARGE, 10010L),
+                    new PointHistory(4L, USER_ID, 80L, TransactionType.USE, 10015L)
+            );
+            given(pointHistoryTable.selectAllByUserId(USER_ID)).willReturn(history);
+
+            //when, then
+            assertThat(pointHistoryTable.selectAllByUserId(USER_ID)).hasSize(3)
+                    .extracting("id", "userId", "transactionType", "updateMillis")
+                    .containsExactly(
+                            tuple(1L, USER_ID, CURRENT_POINT, TransactionType.CHARGE, UPDATE_MILLIS),
+                            tuple(2L, USER_ID, 400L, TransactionType.USE, 20000L),
+                            tuple(3L, USER_ID, 200L, TransactionType.CHARGE, 22000L)
+                    );
+            verify(pointHistoryTable).selectAllByUserId(USER_ID);
+        }
+    }
+
+    @Nested
+    class 포인트_충전 {
+
+        @Test
+        void 유저_포인트_정상_충전() {
+            //given
+            long chargeAmount = 1L;
+            given(userPointTable.selectById(USER_ID)).willReturn(new UserPoint(USER_ID, CURRENT_POINT, UPDATE_MILLIS));
+            given(userPointTable.insertOrUpdate(USER_ID, chargeAmount)).willReturn(new UserPoint(USER_ID, chargeAmount, UPDATE_MILLIS));
+
+            //when, then
+            assertThat(pointService.chargePointOf(USER_ID, chargeAmount))
+                    .extracting("id", "point", "updateMillis")
+                    .containsExactly(USER_ID, CURRENT_POINT + chargeAmount, UPDATE_MILLIS);
+            verify(userPointTable).selectById(USER_ID);
+            verify(userPointTable).insertOrUpdate(USER_ID, CURRENT_POINT + chargeAmount);
+
+        }
+
+        @Test
+        void 회당_최소_충전금액_미달_예외_처리 () {
+            //given
+            long chargeAmount = MINIMUM_CHARGE_AMOUNT - 1L;
+
+            //when, then
+            assertThatThrownBy(() -> pointService.chargePointOf(USER_ID, chargeAmount))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage(MINIMUM_CHARGE_AMOUNT + " 포인트 이상 충전해주세요");
+            verify(userPointTable, never()).insertOrUpdate(anyLong(), anyLong());
+        }
+
+        @Test
+        void 회당_최대_충전금액_초과_예외_처리 () {
+            //given
+            long chargeAmount = MAXIMUM_CHARGE_AMOUNT + 1L;
+
+            //when, then
+            assertThatThrownBy(() -> pointService.chargePointOf(USER_ID, chargeAmount))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("1회 최대 충전금액은  " + MAXIMUM_CHARGE_AMOUNT + "입니다.");
+            verify(userPointTable, never()).insertOrUpdate(anyLong(), anyLong());
+
+        }
+
+        @Test
+        void 최대_잔고_초과_예외_처리 () {
+            //given
+            long chargeAmount = MAXIMUM_CHARGE_AMOUNT - CURRENT_POINT + 1L;
+            given(userPointTable.selectById(USER_ID))
+                    .willReturn(new UserPoint(USER_ID, CURRENT_POINT, UPDATE_MILLIS));
+
+            //when, then
+            assertThatThrownBy(() -> pointService.chargePointOf(USER_ID, chargeAmount))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("보유 가능한 최대 포인트를 초과했습니다. (최대 보유 가능 포인트: " + MAXIMUM_BALANCE + ")");
+            verify(userPointTable).selectById(USER_ID);
+            verify(userPointTable, never()).insertOrUpdate(anyLong(), anyLong());
+        }
+    }
+
+    @Nested
+    class 포인트_사용 {
+
+        @Test
+        void 유저_포인트_정상_사용 () {
+            //given
+            long useAmount = 500L;
+            given(userPointTable.selectById(USER_ID))
+                    .willReturn(new UserPoint(USER_ID, CURRENT_POINT, UPDATE_MILLIS));
+            given(userPointTable.insertOrUpdate(USER_ID, CURRENT_POINT - useAmount))
+                    .willReturn(new UserPoint(USER_ID, CURRENT_POINT - useAmount, UPDATE_MILLIS));
+
+            //when, then
+            assertThat(pointService.usePointOf(USER_ID, useAmount))
+                    .extracting("id", "point", "updateMillis")
+                    .containsExactly(USER_ID, CURRENT_POINT - useAmount, UPDATE_MILLIS);
+            verify(userPointTable).selectById(USER_ID);
+            verify(userPointTable).insertOrUpdate(USER_ID, CURRENT_POINT - useAmount);
+        }
+
+        @Test
+        void 회당_최소_사용금액_미달_예외_처리 () {
+            //given
+            long useAmount = MINIMUM_USE_AMOUNT - 1L;
+
+            //when, then
+            assertThatThrownBy(() -> pointService.usePointOf(USER_ID, useAmount))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage(MINIMUM_USE_AMOUNT + " 포인트 이상 사용해주세요.");
+        }
+
+        @Test
+        void 회당_최대_사용금액_초과_예외_처리 () {
+            //given
+            long useAmount = MAXIMUM_USE_AMOUNT + 1L;
+
+            //when, then
+            assertThatThrownBy(() -> pointService.usePointOf(USER_ID, useAmount))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("1회 최대 사용금액은 " + MAXIMUM_USE_AMOUNT + "입니다.");
+        }
+
+        @Test
+        void 잔고를_초과한_금액_사용_시도_예외_처리 () {
+            //given
+            long useAmount = CURRENT_POINT + 1L;
+            given(userPointTable.selectById(USER_ID)).willReturn(new UserPoint(USER_ID, CURRENT_POINT, UPDATE_MILLIS));
+
+            //when, then
+            assertThatThrownBy(() -> pointService.usePointOf(USER_ID, useAmount))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("사용할 포인트가 부족합니다. (현재 보유 포인트: " + CURRENT_POINT + ")");
+        }
+    }
+
+    @Nested
+    class 히스토리_저장 {
+
+        @Test
+        void 포인트_충전_시_히스토리_갱신 () {
+            //given
+            long chargeAmount = 500L;
+            given(userPointTable.selectById(USER_ID))
+                    .willReturn(new UserPoint(USER_ID, CURRENT_POINT, UPDATE_MILLIS));
+            given(userPointTable.insertOrUpdate(USER_ID, CURRENT_POINT + chargeAmount))
+                    .willReturn(new UserPoint(USER_ID, CURRENT_POINT + chargeAmount, UPDATE_MILLIS));
+            //when
+            pointService.chargePointOf(USER_ID, chargeAmount);
+
+            //then
+            verify(pointHistoryTable).insert(USER_ID, chargeAmount, TransactionType.CHARGE, UPDATE_MILLIS);
+        }
+
+        @Test
+        void 포인트_사용_시_히스토리_갱신() {
+            //given
+            long useAmount = 500L;
+            given(userPointTable.selectById(USER_ID))
+                    .willReturn(new UserPoint(USER_ID, CURRENT_POINT, UPDATE_MILLIS));
+            given(userPointTable.insertOrUpdate(USER_ID, CURRENT_POINT - useAmount))
+                    .willReturn(new UserPoint(USER_ID, CURRENT_POINT - useAmount, UPDATE_MILLIS));
+
+            //when
+            pointService.usePointOf(USER_ID, useAmount);
+
+            //then
+            verify(pointHistoryTable).insert(USER_ID, useAmount, TransactionType.USE, UPDATE_MILLIS);
+        }
+
+        @Test
+        void 충전_실패시_히스토리_저장되지_않음() {
+            //given
+            long chargeAmount = MAXIMUM_CHARGE_AMOUNT + 1L;
+
+            //then
+            assertThatThrownBy(() -> pointService.chargePointOf(USER_ID, chargeAmount))
+                    .isInstanceOf(RuntimeException.class);
+
+            verify(userPointTable, never()).selectById(anyLong());
+            verify(pointHistoryTable, never()).insert(anyLong(), anyLong(), any(), anyLong());
+        }
+
+        @Test
+        void 사용_실패시_히스토리_저장되지_않음() {
+            //given
+            long useAmount = CURRENT_POINT + 1L;
+
+            //then
+            assertThatThrownBy(() -> pointService.usePointOf(USER_ID, useAmount))
+                    .isInstanceOf(RuntimeException.class);
+            verify(pointHistoryTable, never()).insert(anyLong(), anyLong(), any(), anyLong());
+        }
+    }
 }

--- a/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-public class PointServiceUnitTest {
+public class PointServiceTest {
 
     // 기본 값
     private final Long USER_ID = 1L;
@@ -70,16 +70,18 @@ public class PointServiceUnitTest {
         void 유저_포인트_히스토리_정상조회() {
             //given
             List<PointHistory> history = List.of(
-                    new PointHistory(1L, USER_ID, 100L, TransactionType.CHARGE, 10000L),
-                    new PointHistory(2L, USER_ID, 50L, TransactionType.USE, 10005L),
-                    new PointHistory(3L, USER_ID, 70L, TransactionType.CHARGE, 10010L),
-                    new PointHistory(4L, USER_ID, 80L, TransactionType.USE, 10015L)
+                    new PointHistory(1L, USER_ID, CURRENT_POINT, TransactionType.CHARGE, UPDATE_MILLIS),
+                    new PointHistory(2L, USER_ID, 400L, TransactionType.USE, 20000L),
+                    new PointHistory(3L, USER_ID, 200L, TransactionType.CHARGE, 22000L)
             );
             given(pointHistoryTable.selectAllByUserId(USER_ID)).willReturn(history);
 
-            //when, then
-            assertThat(pointHistoryTable.selectAllByUserId(USER_ID)).hasSize(3)
-                    .extracting("id", "userId", "transactionType", "updateMillis")
+            //when
+            List<PointHistory> result = pointService.getPointHistoriesOf(USER_ID);
+
+            // then
+            assertThat(result).hasSize(3)
+                    .extracting("id", "userId", "amount", "type", "updateMillis")
                     .containsExactly(
                             tuple(1L, USER_ID, CURRENT_POINT, TransactionType.CHARGE, UPDATE_MILLIS),
                             tuple(2L, USER_ID, 400L, TransactionType.USE, 20000L),

--- a/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
@@ -114,7 +114,7 @@ public class PointServiceTest {
             //when, then
             assertThatThrownBy(() -> pointService.chargePointOf(USER_ID, chargeAmount))
                     .isInstanceOf(RuntimeException.class)
-                    .hasMessage(MINIMUM_CHARGE_AMOUNT + " 포인트 이상 충전해주세요");
+                    .hasMessage(MINIMUM_CHARGE_AMOUNT + " 포인트 이상 충전해주세요.");
             verify(userPointTable, never()).insertOrUpdate(anyLong(), anyLong());
         }
 
@@ -126,7 +126,7 @@ public class PointServiceTest {
             //when, then
             assertThatThrownBy(() -> pointService.chargePointOf(USER_ID, chargeAmount))
                     .isInstanceOf(RuntimeException.class)
-                    .hasMessage("1회 최대 충전금액은  " + MAXIMUM_CHARGE_AMOUNT + "입니다.");
+                    .hasMessage("1회 최대 충전금액은 " + MAXIMUM_CHARGE_AMOUNT + "입니다.");
             verify(userPointTable, never()).insertOrUpdate(anyLong(), anyLong());
 
         }


### PR DESCRIPTION
### **커밋 링크**

[feat] PointService 기능 구현: [eee0e75](https://github.com/dahlbong/point-TDD/commit/eee0e75)
[test] 유닛 테스트 구현: [b3ca13d](https://github.com/dahlbong/point-TDD/commit/b3ca13d)  [8e2ebe7](https://github.com/dahlbong/point-TDD/commit/8e2ebe7470ac69d94c863c5ef22d41f9357c2ebb)
[refactor] 비즈니스 요구에 따라 변경되는 상수 분리: [941b5e2](https://github.com/dahlbong/point-TDD/commit/941b5e25b0c53bb42d71b26fd27c13cac18039fa)
[feat] 충전/사용 테스트에 따른 Pointvalidator 생성: [2277b29](https://github.com/dahlbong/point-TDD/commit/2277b2992000c65bfe2d570c7431473ebe482534)
[refactor] OOP 준수하여 UserPoint에 잔액 계산 로직 이관: [f95cd0](https://github.com/dahlbong/point-TDD/commit/f95c3d032248dfac54368655ebc610e5f2732048)

---
### **리뷰 포인트(질문)**
- 커밋 단위가 이게 맞는지 잘 모르겠습니다.  (처음에 큰 틀을 잡을 때는 뭉텅이 단위로 커밋이 컸다가, 나중에 테스트 케이스를 보며 리팩토링/오류 수정을 진행할 때는 커밋 단위가 너무 잘게 쪼개지는 것 같은 느낌(?) 입니다,,)
- 유닛 테스트의 실패 케이스를 최대한 edge case로 구성하려고 했는데, 이런식으로 하는게 맞는지, 테스트케이스의 양은 충분한지, 빠뜨린 테스트가 있다면 어떤 것이 있을지 궁금합니다.

---
### **이번주 KPT 회고**

### Keep
- TDD의 강력함을 체감했습니다. Service/Controller의 큰 틀만 구성한 후, 테스트케이스를 하나씩 만족시켜 나가는 식으로 개발을 진행하니 시퀀스가 훨씬 정돈될 수 있었습니다.

### Problem
- 주어진 Database 패키지 내의 메서드들을 정확히 파악하지 않고 테스트코드 작성에 들어가 중간에 테스트케이스의 파라미터를 수정하는 일이 발생했습니다. 만약 코드가 주어진 상황이라면, 문맥을 정확히 파악/정의한 후 구현에 들어가야함을 느꼈습니다.

### Try
- 동시성 제어 구현